### PR TITLE
implement sign_prepend for multisig aggregate

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ This scheme is from the BLS spec in the IETF. AugSchemeMPL is used by the Chia N
 -   `message` is a `Uint8Array`.
 -   Returns a `JacobianPoint` signature.
 
+### static sign_prepend(privateKey, message, prependPublicKey)
+
+-   `privateKey` is a `PrivateKey`.
+-   `message` is a `Uint8Array`.
+-   `prependPublicKey` is a `JacobianPoint` public key.
+-   Returns a `JacobianPoint` signature.
+
 ### static verify(publicKey, message, signature)
 
 -   `publicKey` is a `JacobianPoint` public key.

--- a/src/types/schemes/AugSchemeMPL.ts
+++ b/src/types/schemes/AugSchemeMPL.ts
@@ -29,6 +29,18 @@ export class AugSchemeMPL {
         );
     }
 
+    public static sign_prepend(
+        privateKey: PrivateKey,
+        message: Uint8Array,
+        prependPublicKey: JacobianPoint
+    ): JacobianPoint {
+        return coreSignMpl(
+            privateKey,
+            Uint8Array.from([...prependPublicKey.toBytes(), ...message]),
+            augSchemeDst
+        );
+    }
+
     public static verify(
         publicKey: JacobianPoint,
         message: Uint8Array,

--- a/test/test.ts
+++ b/test/test.ts
@@ -740,6 +740,12 @@ describe('Readme', () => {
     const grandchildUPk = AugSchemeMPL.deriveChildPkUnhardened(childUPk, 0);
     it('AugSchemeMPL child keys', () =>
         assert(grandchildUPk.equals(grandchildU.getG1())));
+    const aggPk = pk1.add(pk2);
+    const aggSig1 = AugSchemeMPL.sign_prepend(sk1, message, aggPk);
+    const aggSig2 = AugSchemeMPL.sign_prepend(sk2, message, aggPk);
+    var prependAggSig = AugSchemeMPL.aggregate([aggSig1, aggSig2]);
+    it('AugSchemeMPL prepend verify', () =>
+        assert(AugSchemeMPL.verify(aggPk, message, prependAggSig)));
 });
 
 describe('Current', () => {


### PR DESCRIPTION
Motivation: function `sign_prepend` is necessary for multisig aggregate.

### The function signature follows: 
https://github.com/Chia-Network/bls-signatures/blob/0b56b3d6f01b485e43abd8edf3638e9f60951c7a/js-bindings/blsjs.d.ts#L5
```
  static sign_prepend(sk: PrivateKey, msg: Uint8Array, prependPk: G1Element): G2Element;
```

### The test cases follows:
https://github.com/Chia-Network/bls-signatures/blob/0b56b3d6f01b485e43abd8edf3638e9f60951c7a/js-bindings/tests/test.js#L83-L84
```
            // Aggregate same message
            const agg_pk = pk1.add(pk2);
            var sig1, sig2;
            if (Scheme === AugSchemeMPL) {
                sig1 = Scheme.sign_prepend(sk1, msg, agg_pk);
                sig2 = Scheme.sign_prepend(sk2, msg, agg_pk);
            } else {
                sig1 = Scheme.sign(sk1, msg);
                sig2 = Scheme.sign(sk2, msg);
            }

            var agg_sig = Scheme.aggregate([sig1, sig2]);
            assert(Scheme.verify(agg_pk, msg, agg_sig));
```
